### PR TITLE
Eliminate reliance on math.Gamma

### DIFF
--- a/fet.go
+++ b/fet.go
@@ -214,12 +214,12 @@ func main() {
 	var x float64 = 5.5
 	var y float64 = 3
 	var a, b float64
-	fmt.Printf("erfc(%lg): %lg, %lg\n", x, math.Erfc(x), kf_erfc(x))
-	fmt.Printf("upper-gamma(%lg,%lg): %lg\n", x, y, kf_gammaq(y, x)*math.Gamma(y)) // is tgamma == math.Gamma ?
+	fmt.Printf("erfc(%v): %v, %v\n", x, math.Erfc(x), kf_erfc(x))
+	fmt.Printf("upper-gamma(%v,%v): %v\n", x, y, kf_gammaq(y, x)*math.Gamma(y)) // is tgamma == math.Gamma ?
 	a = 2
 	b = 2
 	x = 0.5
-	fmt.Printf("incomplete-beta(%lg,%lg,%lg): %lg\n", a, b, x, kf_betai(a, b, x)/math.Exp(kf_lgamma(a+b)-kf_lgamma(a)-kf_lgamma(b)))
+	fmt.Printf("incomplete-beta(%v,%v,%v): %v\n", a, b, x, kf_betai(a, b, x)/math.Exp(kf_lgamma(a+b)-kf_lgamma(a)-kf_lgamma(b)))
 
 }
 
@@ -235,7 +235,8 @@ func lbinom(n int, k int) float64 {
 // value of the gamma function of x.
 // ex: lgamma (0.500000) = 0.572365
 func lgamma(x float64) float64 {
-	return math.Log(math.Abs(math.Gamma(x)))
+	xG, _ := math.Lgamma(x)
+	return xG
 }
 
 // n11  n12  | n1_
@@ -285,20 +286,20 @@ func hypergeo_acc(n11 int, n1_ int, n_1 int, n int, aux *hgacc_t) float64 {
 }
 
 // FisherExactTest computes Fisher's Exact Test for
-//  contigency tables. Nomenclature:
 //
-//    n11  n12  | n1_
-//    n21  n22  | n2_
-//   -----------+----
-//    n_1  n_2  | n
+//	contigency tables. Nomenclature:
+//
+//	  n11  n12  | n1_
+//	  n21  n22  | n2_
+//	 -----------+----
+//	  n_1  n_2  | n
 //
 // Returned values:
 //
-//  probOfCurrentTable = probability of the current table
-//  leftp = the left sided alternative's p-value  (h0: odds-ratio is less than 1)
-//  rightp = the right sided alternative's p-value (h0: odds-ratio is greater than 1)
-//  twop = the two-sided p-value for the h0: odds-ratio is different from 1
-//
+//	probOfCurrentTable = probability of the current table
+//	leftp = the left sided alternative's p-value  (h0: odds-ratio is less than 1)
+//	rightp = the right sided alternative's p-value (h0: odds-ratio is greater than 1)
+//	twop = the two-sided p-value for the h0: odds-ratio is different from 1
 func FisherExactTest(n11 int, n12 int, n21 int, n22 int) (probOfCurrentTable, leftp, rightp, twop float64) {
 	var i, j, max, min int
 	var p float64

--- a/fet_test.go
+++ b/fet_test.go
@@ -39,6 +39,35 @@ func TestFisherExact(t *testing.T) {
 		cv.So(EpsEquals(fisher_twosided_p, 0.294912, eps), cv.ShouldBeTrue)
 		cv.So(EpsEquals(probOfTable, 0.08977114317069486, eps), cv.ShouldBeTrue)
 	})
+
+	cv.Convey("not exposed to math.Gamma limitation", t, func() {
+
+		var fisher_left_p, fisher_right_p, fisher_twosided_p float64
+		probOfTable, fisher_left_p, fisher_right_p, fisher_twosided_p := FisherExactTest(36, 49, 37, 49)
+		fmt.Printf("\n\n probOfTable = %v\n", probOfTable)
+		fmt.Printf("\n\nleft greater - pval = %v\n", fisher_left_p)
+		fmt.Printf("right greater - pval = %v\n", fisher_right_p)
+		fmt.Printf("twosided - pval = %v\n", fisher_twosided_p)
+		/*
+			The c-implementation gives:
+
+			left greater - pval 0.147456   // R agrees: p-value = 0.1475
+			right greater - pval 0.942315  // R agrees: p-value = 0.9423 // alt="greater"
+			twosided - pval 0.294912 // agrees with R: 0.2949
+
+			R code:
+
+			fisher.test(matrix(nrow=2,ncol=2,data=c(10,20,15,15)))
+			fisher.test(matrix(nrow=2,ncol=2,data=c(10,20,15,15)), alternative="greater") // p=0.9423
+			fisher.test(matrix(nrow=2,ncol=2,data=c(10,20,15,15)), alternative="less")
+		*/
+
+		cv.So(EpsEquals(fisher_left_p, 0.526315, eps), cv.ShouldBeTrue)
+		cv.So(EpsEquals(fisher_right_p, 0.596015, eps), cv.ShouldBeTrue)
+		cv.So(EpsEquals(fisher_twosided_p, 1.0, eps), cv.ShouldBeTrue)
+		cv.So(EpsEquals(probOfTable, 0.12232960808114068, eps), cv.ShouldBeTrue)
+	})
+
 }
 
 func EpsEquals(a, b, eps float64) bool {


### PR DESCRIPTION
go 1.19 (and earlier) math.Gamma uses Stirling's formula which returns infinity for for 172 <= x <= 180 . Using Lgamma avoids this break in continuity which caused incorrect fet results.
- test case added to prevent regression
- gofmt changes for comments
- changed invalid %lg to %v 